### PR TITLE
Avoid dropping duplicates when calculating scores awarded wrt gender

### DIFF
--- a/eurovision/notebooks/story.ipynb
+++ b/eurovision/notebooks/story.ipynb
@@ -1932,7 +1932,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gender_df = df[['year', 'to_code2', 'gender', 'points']].copy().drop_duplicates()\n",
+    "gender_df = df[['year', 'to_code2', 'gender', 'points']].copy()\n",
     "genders = list(gender_colours.keys())[:3]\n",
     "votes = []\n",
     "fig = plt.figure(figsize=(10, 5))\n",


### PR DESCRIPTION
Since the table doesn't include the 'from_code2' column it's important not to drop duplicates. Dropping duplicates would mean merging all rows where the same country was given the same score in the same year by multiple countries. However, this is not an unusual circumstance, and the votes should be counted separately in this case (rather than being merged into a single vote).